### PR TITLE
Fix for timestamp processing to work with Python 3.6

### DIFF
--- a/preprocessing/label.py
+++ b/preprocessing/label.py
@@ -20,7 +20,7 @@ def label_group(group):
       ts = parser.parse(alert.d['timestamp']).timestamp()
     elif '@timestamp' in alert.d:
       # For Wazuh alerts from the AIT-ADS
-      ts = datetime.strptime(alert.d['@timestamp'], "%Y-%m-%dT%H:%M:%S.%f%z").timestamp()
+      ts = parser.isoparse(alert.d['@timestamp']).timestamp()
     elif 'LogData' in alert.d and 'Timestamps' in alert.d['LogData']:
       # For AMiner alerts
       ts = alert.d['LogData']['Timestamps'][0]

--- a/preprocessing/preprocess.py
+++ b/preprocessing/preprocess.py
@@ -99,7 +99,7 @@ def read_ossec_full_json(filename):
           timestamps.append(parser.parse(alert_obj.d['timestamp']).timestamp())
       else:
           # In alerts from AIT-ADS, field is named '@timestamp'
-          timestamps.append(datetime.strptime(alert_obj.d['@timestamp'], "%Y-%m-%dT%H:%M:%S.%f%z").timestamp())
+          timestamps.append(parser.isoparse(alert_obj.d['@timestamp']).timestamp())
   return alerts, timestamps
 
 def read_aminer_json(filename):


### PR DESCRIPTION
strptime in Python 3.6 is unable to handle ISO8601 timestamps with 'Z' as the time zone indicator. This functionality was added in Python 3.7:

https://docs.python.org/3/library/datetime.html#strftime-and-strptime-behavior

parser.isoparse is able to handle this correctly in Python 3.6 as well.